### PR TITLE
Support different kinds of queues through a trait.

### DIFF
--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -1,4 +1,4 @@
-use simrs::{Component, ComponentId, Key, QueueId, Scheduler, Simulation, State};
+use simrs::{Component, ComponentId, Fifo, Key, QueueId, Scheduler, Simulation, State};
 use std::time::Duration;
 
 #[derive(Debug)]
@@ -97,7 +97,7 @@ impl Component for Consumer {
 
 fn main() {
     let mut simulation = Simulation::default();
-    let queue = simulation.add_queue::<Product>();
+    let queue = simulation.add_queue(Fifo::default());
     let working_on = simulation.state.insert::<Option<Product>>(None);
     let consumer = simulation.add_component(Consumer {
         incoming: queue,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -96,6 +96,12 @@ pub struct ClockRef {
     clock: Clock,
 }
 
+impl From<Clock> for ClockRef {
+    fn from(clock: Clock) -> Self {
+        Self { clock }
+    }
+}
+
 impl ClockRef {
     /// Return the current simulation time.
     #[must_use]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -96,12 +96,6 @@ pub struct ClockRef {
     clock: Clock,
 }
 
-impl From<Clock> for ClockRef {
-    fn from(clock: Clock) -> Self {
-        Self { clock }
-    }
-}
-
 impl ClockRef {
     /// Return the current simulation time.
     #[must_use]
@@ -140,11 +134,7 @@ impl Scheduler {
     }
 
     /// Schedules `event` to be executed for `component` at `self.time()`.
-    pub fn schedule_immediately<E: fmt::Debug + 'static>(
-        &mut self,
-        component: ComponentId<E>,
-        event: E,
-    ) {
+    pub fn schedule_now<E: fmt::Debug + 'static>(&mut self, component: ComponentId<E>, event: E) {
         self.schedule(Duration::default(), component, event);
     }
 
@@ -174,6 +164,24 @@ impl Scheduler {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_event_entry_debug() {
+        let entry = EventEntry {
+            time: Reverse(Duration::from_secs(1)),
+            component: 2,
+            inner: Box::new(String::from("inner")),
+        };
+        assert_eq!(
+            &format!("{:?}", entry),
+            "EventEntry { time: Reverse(1s), component: 2, inner: Any }"
+        );
+        let typed = entry.downcast::<String>().unwrap();
+        assert_eq!(
+            &format!("{:?}", typed),
+            "EventEntryTyped { time: 1s, component_id: ComponentId { id: 2, _marker: PhantomData }, component_idx: 2, event: \"inner\" }"
+        );
+    }
 
     #[test]
     fn test_event_entry_downcast() {
@@ -236,13 +244,14 @@ mod test {
     fn test_scheduler() {
         let mut scheduler = Scheduler::default();
         assert_eq!(scheduler.time(), Duration::new(0, 0));
+        assert_eq!(scheduler.clock().time(), Duration::new(0, 0));
         assert!(scheduler.events.is_empty());
 
         let component_a = ComponentId::<EventA>::new(0);
         let component_b = ComponentId::<EventB>::new(1);
 
         scheduler.schedule(Duration::from_secs(1), component_a, EventA);
-        scheduler.schedule(Duration::from_secs(0), component_b, EventB);
+        scheduler.schedule_now(component_b, EventB);
         scheduler.schedule(Duration::from_secs(2), component_b, EventB);
 
         assert_eq!(scheduler.time(), Duration::from_secs(0));
@@ -264,6 +273,7 @@ mod test {
         assert_eq!(entry.event, &EventA);
 
         assert_eq!(scheduler.time(), Duration::from_secs(1));
+        assert_eq!(scheduler.clock().time(), Duration::from_secs(1));
 
         let entry = scheduler.pop().unwrap();
         let entry = entry.downcast::<EventB>().unwrap();


### PR DESCRIPTION
### Breaking change

Instead of `add_queue` and `add_bounded_queue`, there is only `add_queue` that takes the queue as argument. This allows for cleaner API and different queue support:
```rust
simulation.add_queue(Fifo::default());
simulation.add_queue(PriorityQueue::bounded(5));
```
Type inference should work most of the time, which cleans up the code. In case it's not possible, one can instantiate a queue explicitly:
```rust
Fifo::<i32>::default()
```