### PR TITLE
Use queue type for state API

### DIFF
--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -5,13 +5,13 @@ use std::time::Duration;
 struct Product;
 
 struct Producer {
-    outgoing: QueueId<Product>,
+    outgoing: QueueId<Fifo<Product>>,
     consumer: ComponentId<ConsumerEvent>,
     produced_count: Key<usize>,
 }
 
 struct Consumer {
-    incoming: QueueId<Product>,
+    incoming: QueueId<Fifo<Product>>,
     working_on: Key<Option<Product>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,13 +187,13 @@
 //! struct Product;
 //!
 //! struct Producer {
-//!     outgoing: QueueId<Product>,
+//!     outgoing: QueueId<Fifo<Product>>,
 //!     consumer: ComponentId<ConsumerEvent>,
 //!     produced_count: Key<usize>,
 //! }
 //!
 //! struct Consumer {
-//!     incoming: QueueId<Product>,
+//!     incoming: QueueId<Fifo<Product>>,
 //!     working_on: Key<Option<Product>>,
 //! }
 //!
@@ -365,7 +365,7 @@ impl Simulation {
 
     /// Adds a new unbounded queue.
     #[must_use]
-    pub fn add_queue<Q: Queue<V> + 'static, V: 'static>(&mut self, queue: Q) -> QueueId<V> {
+    pub fn add_queue<Q: Queue + 'static>(&mut self, queue: Q) -> QueueId<Q> {
         self.state.add_queue(queue)
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -14,16 +14,19 @@ impl std::fmt::Display for PushError {
 impl std::error::Error for PushError {}
 
 /// Trait implemented by the queues used in the simulation.
-pub trait Queue<T> {
+pub trait Queue {
+    /// Type of elements held by the queue.
+    type Item;
+
     /// Add an element to the queue.
     ///
     /// # Errors
     ///
     /// Returns an error if the queue is bounded in size and full.
-    fn push(&mut self, value: T) -> Result<(), PushError>;
+    fn push(&mut self, value: Self::Item) -> Result<(), PushError>;
 
     /// Removes the next element and returns it, or `None` if the `Queue` is empty.
-    fn pop(&mut self) -> Option<T>;
+    fn pop(&mut self) -> Option<Self::Item>;
 
     /// Returns the number of elements in the queue.
     fn len(&self) -> usize;
@@ -66,7 +69,9 @@ impl<T> Fifo<T> {
     }
 }
 
-impl<T> Queue<T> for Fifo<T> {
+impl<T> Queue for Fifo<T> {
+    type Item = T;
+
     fn push(&mut self, value: T) -> Result<(), PushError> {
         if self.inner.len() < self.capacity {
             self.inner.push_back(value);
@@ -111,7 +116,9 @@ impl<T: Ord> PriorityQueue<T> {
     }
 }
 
-impl<T: Ord> Queue<T> for PriorityQueue<T> {
+impl<T: Ord> Queue for PriorityQueue<T> {
+    type Item = T;
+
     fn push(&mut self, value: T) -> Result<(), PushError> {
         if self.inner.len() < self.capacity {
             self.inner.push(value);


### PR DESCRIPTION
#8 introduced a bug that always used `Fifo` for downcasting, and therefore there would be a panic if another type of queue was used. This fixes it by using the type of queue rather than element for the IDs.

Additionally, `Queue` is now not generic but rather has an associated type `Item`.